### PR TITLE
Make use of location names

### DIFF
--- a/console/src/components/IncidentEditor.vue
+++ b/console/src/components/IncidentEditor.vue
@@ -144,6 +144,20 @@
             <button type="button" class="button" @click.prevent="item.location = null">Einsatzort entfernen</button>
             <div class="field is-horizontal">
                 <div class="field-label is-normal">
+                    <label class="label" for="location_name">Objektname</label>
+                </div>
+                <div class="field-body">
+                    <div class="field">
+                        <div class="control">
+                            <input class="input" type="text" id="location_name" v-model.trim="item.location.name">
+                        </div>
+                        <p class="help">Bezeichnung des Objekts oder der Örtlichkeit</p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="field is-horizontal">
+                <div class="field-label is-normal">
                     <label class="label" for="street">Adresse</label>
                 </div>
                 <div class="field-body">

--- a/server/src/services/locations/locations.class.ts
+++ b/server/src/services/locations/locations.class.ts
@@ -66,6 +66,7 @@ export class Locations extends Service<LocationData> {
       location.locality = rawLocation.city;
     }
 
+    location.name = rawLocation.name;
     location.detail = rawLocation.detail;
 
     return location;

--- a/server/src/services/textanalysis/analyser.class.ts
+++ b/server/src/services/textanalysis/analyser.class.ts
@@ -61,6 +61,7 @@ export class Analyser {
         number: matches.get('caller_number') as string || ''
       },
       location: {
+        name: matches.get('loc_name') as string || '',
         street: matches.get('loc_street') as string || '',
         streetnumber: matches.get('loc_streetnumber') as string || '',
         detail: matches.get('loc_detail') as string || '',

--- a/server/src/services/textanalysis/configs/ILS_Augsburg.ts
+++ b/server/src/services/textanalysis/configs/ILS_Augsburg.ts
@@ -40,6 +40,7 @@ export default {
       regexps: [
         /Straße\s*[:;=](?<loc_street>.*)Haus-Nr\.[:;=]\s*(?<loc_streetnumber>\d+(?:\s?[a-z])?)(?<loc_detail>\s+.*)?$/,
         /Ort\s*[:;=]\s*(?<loc_zip>\d{5}) (?<loc_city>\w+)/,
+        /Objekt\s*[:;=]\s*(?<loc_name>.+)$/,
         /Koordinate\s*[:;=]\s(?<loc_gk_x>\d+[,.]\d+) \/ (?<loc_gk_y>\d+[,.]\d+)$/
       ]
     },

--- a/server/src/services/textanalysis/textanalysis.service.ts
+++ b/server/src/services/textanalysis/textanalysis.service.ts
@@ -73,6 +73,7 @@ declare module '../../declarations' {
      * - loc_detail: Additional detail for the incident location (e. g. 1st floor)
      * - loc_gk_x: X component of a Gauss Krueger coordinate of the incident location
      * - loc_gk_y: Y component of a Gauss Krueger coordinate of the incident location
+     * - loc_name: A well-known name of the incident location (e. g. a building or company name)
      * - loc_street: The street name of the incident location
      * - loc_streetnumber: The street number of the incident location
      * - loc_wgs84_lat: Latitude of WGS84 coordinate, either as decimal number on its own or as integer if combined with loc_wgs84_lat_min and loc_wgs84_lat_sec
@@ -114,6 +115,7 @@ declare module '../../declarations' {
   }
 
   interface RawLocation {
+    name: string
     street: string
     streetnumber: string
     detail: string


### PR DESCRIPTION
While names for locations were already in the data model, they have not been usable yet. This PR enables their usage in text analysis configs and the incident editor.

closes #20 